### PR TITLE
Fix crash when optional-mods folder is missing.

### DIFF
--- a/src/main/java/com/troblecodings/launcher/javafx/OptionalModsScene.java
+++ b/src/main/java/com/troblecodings/launcher/javafx/OptionalModsScene.java
@@ -71,6 +71,9 @@ public class OptionalModsScene extends Scene {
 
     private static void RefreshOptionalMods(VBox vBox) {
         try {
+            if(!Files.exists(optionalModsPath))
+                Files.createDirectories(optionalModsPath);
+
             optionalMods.forEach(mod -> {
                 vBox.getChildren().remove(mod);
             });


### PR DESCRIPTION
Add a missing check for the optional-mods directory, for the case of it missing, which causes a crash to occur.