### PR TITLE
Verify that mods are not present before copying.

### DIFF
--- a/src/main/java/com/troblecodings/launcher/util/StartupUtil.java
+++ b/src/main/java/com/troblecodings/launcher/util/StartupUtil.java
@@ -68,6 +68,7 @@ public class StartupUtil {
 		if (!Launcher.getBetaMode())
 			return new BetaInfo[0];
 
+		List<BetaInfo> betaInfo = new ArrayList<>();
 		String betaJsonPath = FileUtil.SETTINGS.baseDir + "/beta.json";
 		String content;
 
@@ -76,26 +77,22 @@ public class StartupUtil {
 				refreshBetaJson();
 
 			content = new String(Files.readAllBytes(Paths.get(betaJsonPath)));
-		} catch (IOException e) {
-			Launcher.onError(e);
-			return new BetaInfo[0];
-		}
 
-		List<BetaInfo> betaInfo = new ArrayList<>();
-
-		try {
 			JSONObject root = new JSONObject(content);
 
 			root.keySet().forEach(key -> {
 				JSONObject mod = root.getJSONObject(key);
 				mod.keySet().forEach(pr -> {
-					JSONObject prObj = mod.getJSONObject(pr);
-					BetaInfo info = new BetaInfo(key, Integer.parseInt(pr), prObj.getString("name"), prObj.getString("download"), prObj.getInt("port"));
-					betaInfo.add(info);
+					try {
+						JSONObject prObj = mod.getJSONObject(pr);
+						BetaInfo info = new BetaInfo(key, Integer.parseInt(pr), prObj.getString("name"), prObj.getString("download"), prObj.getInt("port"));
+						betaInfo.add(info);
+					} catch (Exception ignored) {
+					}
 				});
 			});
 		} catch (Exception e) {
-			Launcher.getLogger().trace("Beta.json is incorrectly formatted!", e);
+			Launcher.getLogger().trace("Could not parse beta.json!", e);
 			return new BetaInfo[0];
 		}
 
@@ -390,7 +387,7 @@ public class StartupUtil {
 
 					if(Files.exists(path))
 						return;
-					
+
 					Files.copy(pth, path);
 				} catch (IOException e) {
 					Launcher.onError(e);

--- a/src/main/java/com/troblecodings/launcher/util/StartupUtil.java
+++ b/src/main/java/com/troblecodings/launcher/util/StartupUtil.java
@@ -386,7 +386,12 @@ public class StartupUtil {
 			Files.createDirectories(additionalMods);
 			Files.list(additionalMods).filter(pth -> !pth.toString().endsWith(".dis")).forEach(pth -> {
 				try {
-					Files.copy(pth, Paths.get(pth.toString().replace("additional-mods", "mods")));
+					Path path = Paths.get(pth.toString().replace("additional-mods", "mods"));
+
+					if(Files.exists(path))
+						return;
+					
+					Files.copy(pth, path);
 				} catch (IOException e) {
 					Launcher.onError(e);
 				}


### PR DESCRIPTION
Previously, if a mod that hasn't been properly removed exists and is tried to be copied over, an exception would be thrown, since `Files.copy()` does not overwrite files.
This has been fixed by implementing a small check for the file existing and returning if it exists.

This pr also changes the try-catch logic of `getBetaVersions()` to ignore malformed json bodies and only throw on serious exceptions.