### PR TITLE
Change regex to only search for `.jar` at the end of the file name

### DIFF
--- a/src/main/java/com/troblecodings/launcher/javafx/OptionalModsScene.java
+++ b/src/main/java/com/troblecodings/launcher/javafx/OptionalModsScene.java
@@ -84,7 +84,7 @@ public class OptionalModsScene extends Scene {
                 String fileName = filePath.toFile().getName();
                 final CheckBox chkBox = new CheckBox();
                 chkBox.setSelected(FileUtil.SETTINGS.optionalMods.contains(fileName));
-                chkBox.setText(fileName.split("\\.")[0]);
+                chkBox.setText(fileName.split("\\.jar$")[0]);
                 chkBox.setOnAction(ev -> {
                     if(chkBox.isIndeterminate())
                         return;


### PR DESCRIPTION
This pr fixes a regex that was splitting all occurrences of `.` when we can also just search for `.jar` at the ned of the file name string.