### PR TITLE
[CVE-2021-44228] Update logj42 to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,13 +110,13 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.14.0</version>
+			<version>2.15.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.14.0</version>
+			<version>2.15.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Fixes [CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q) in the launcher.
Furthermore you **must** update forge to **14.23.5.2859** to fix this issue.

To test paste ``${date:YYYY}`` in the minecraft chat. If its replaced by the current year, then it's **not** fixed.
(Proof of concept here: https://github.com/HyCraftHD/Log4J-RCE-Proof-Of-Concept)

More information about forge here: https://gist.github.com/TheCurle/f15a6b63ceee3be58bff5e7a97c3a4e6