### PR TITLE
Fix for invalid alternative java path selection

### DIFF
--- a/src/main/java/com/troblecodings/launcher/javafx/OptionsScene.java
+++ b/src/main/java/com/troblecodings/launcher/javafx/OptionsScene.java
@@ -3,7 +3,6 @@ package com.troblecodings.launcher.javafx;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.io.File;
-import java.nio.file.Path;
 
 import com.troblecodings.launcher.Launcher;
 import com.troblecodings.launcher.assets.Assets;
@@ -109,13 +108,7 @@ public class OptionsScene extends Scene {
 			chooser.getExtensionFilters().add(new ExtensionFilter("Java executable", "java.exe"));
 			File selectedFile = chooser.showOpenDialog(Launcher.getStage());
 			if (selectedFile != null) {
-				Path javapath = selectedFile.toPath().getParent();
-				if (StartupUtil.isJavaAnd8(javapath)) {
-					String javastring = javapath.toString();
-					javaversionfield.setText(javastring);
-					FileUtil.SETTINGS.javaPath = javastring;
-				}
-
+    			javaversionfield.setText(FileUtil.SETTINGS.javaPath = selectedFile.getPath());
 			}
 		});
 
@@ -160,11 +153,11 @@ public class OptionsScene extends Scene {
 		optionalModsButton.setOnAction(ev -> {
 			Launcher.setScene(Launcher.OPTIONALMODS);
 		});
-		
+
 		final HBox logouthbox = new HBox(10);
 		logouthbox.setPrefWidth(hbox.getPrefWidth());
 		logouthbox.getChildren().addAll(logout, resetconfigs, optionalModsButton);
-		
+
 		final Label lar = new Label("Logout & Reset");
 		lar.setStyle("-fx-padding: 20px 0px 10px 0px;");
 
@@ -225,5 +218,4 @@ public class OptionsScene extends Scene {
 		settingsTrainView.setTranslateY(360 - settingsTrainView.getImage().getHeight());
 		stackpane.getChildren().add(settingsTrainView);
 	}
-
 }

--- a/src/main/java/com/troblecodings/launcher/util/StartupUtil.java
+++ b/src/main/java/com/troblecodings/launcher/util/StartupUtil.java
@@ -461,12 +461,15 @@ public class StartupUtil {
 		if (javaVersionPath.isEmpty()) {
 			Optional<String> javaVers = findJavaVersion();
 			if (!javaVers.isPresent()) {
-				javaVersionPath = "";
+				javaVersionPath = "java";
 				Launcher.getLogger().warn("Java version not found! Falling back!");
 			} else {
 				javaVersionPath = javaVers.get() + "/";
 			}
 		}
+
+        if(!Files.exists(Paths.get(javaVersionPath)) || !javaVersionPath.endsWith("java.exe"))
+            javaVersionPath = "java";
 
 		String[] parameter = prestart();
 		if (parameter == null)
@@ -475,7 +478,7 @@ public class StartupUtil {
 		String width = String.valueOf(FileUtil.SETTINGS.width);
 		String height = String.valueOf(FileUtil.SETTINGS.height);
 		String ram = String.valueOf(FileUtil.SETTINGS.ram);
-		String[] preparameter = new String[] { javaVersionPath + "java", "-Xmx" + ram + "M", "-Xms" + ram + "M",
+		String[] preparameter = new String[] { javaVersionPath, "-Xmx" + ram + "M", "-Xms" + ram + "M",
 				"-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump",
 				"-Djava.library.path=" + FileUtil.LIB_DIR, "-cp", LIBPATHS, MAINCLASS, "-width", width, "-height",
 				height };


### PR DESCRIPTION
Previously, the file picker used the parent directory path and not the full file path.
Note that we are now not validating if the provided `java.exe` is actually from the version `8`.