### PR TITLE
Fix migrations not working correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.21.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.25.3</version>

--- a/src/main/java/com/troblecodings/launcher/javafx/CreditsScene.java
+++ b/src/main/java/com/troblecodings/launcher/javafx/CreditsScene.java
@@ -94,6 +94,11 @@ public class CreditsScene extends Scene {
         commonsLangButton.getStyleClass().add("link");
         vbox.getChildren().add(commonsLangButton);
 
+        Button commonsIoButton = new Button("commons-io: Apache License 2.0 [GitHub]");
+        commonsIoButton.setOnAction(e -> openWebsiteInBrowser("https://github.com/apache/commons-io/blob/master/LICENSE.txt"));
+        commonsIoButton.getStyleClass().add("link");
+        vbox.getChildren().add(commonsIoButton);
+
         Button devDirsButton = new Button("directories-jvm: MPL Version 2.0 [GitHub]");
         devDirsButton.setOnAction(e -> openWebsiteInBrowser("https://codeberg.org/dirs/directories-jvm/src/branch/main/LICENSE"));
         devDirsButton.getStyleClass().add("link");

--- a/src/main/java/com/troblecodings/launcher/util/FileUtil.java
+++ b/src/main/java/com/troblecodings/launcher/util/FileUtil.java
@@ -15,7 +15,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class FileUtil {
@@ -182,9 +183,25 @@ public class FileUtil {
             return;
         }
 
-        FileUtils.deleteDirectory(LauncherPaths.getDataDir().toFile());
-        FileUtils.moveDirectory(oldPath.toFile(), LauncherPaths.getDataDir().toFile());
+        // Skip 1, index 0 is the Roaming/gir/ directory file entry. We don't want to move that.
+        try (Stream<Path> walk = Files.walk(oldPath).skip(1)) {
+            Path dataDir = LauncherPaths.getDataDir();
+            List<Path> files = walk.collect(Collectors.toList());
 
-        log.info("Migrated old directory to new location.");
+            for (Path p : files) {
+                Path relPath = oldPath.relativize(p);
+                Path newPath = dataDir.resolve(relPath);
+
+                if (Files.isDirectory(p)) {
+                    log.debug("Creating directory {} if it doesn't exist", relPath);
+                    Files.createDirectories(newPath);
+                } else {
+                    log.debug("Migrating {} to new folder", relPath);
+                    Files.copy(p, newPath, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+
+        log.info("Copied old directory to new location. You are free to delete the old directory now.");
     }
 }

--- a/src/main/java/com/troblecodings/launcher/util/FileUtil.java
+++ b/src/main/java/com/troblecodings/launcher/util/FileUtil.java
@@ -183,6 +183,12 @@ public class FileUtil {
             return;
         }
 
+        Path migrationStateFile = LauncherPaths.getDataDir().resolve(".did-migrate");
+        if(Files.exists(migrationStateFile)) {
+            log.info("Migration already occurred, nothing to migrate.");
+            return;
+        }
+
         // Skip 1, index 0 is the Roaming/gir/ directory file entry. We don't want to move that.
         try (Stream<Path> walk = Files.walk(oldPath).skip(1)) {
             Path dataDir = LauncherPaths.getDataDir();
@@ -202,6 +208,7 @@ public class FileUtil {
             }
         }
 
-        log.info("Copied old directory to new location. You are free to delete the old directory now.");
+        Files.createFile(migrationStateFile);
+        log.info("Migration complete. You may now delete the old directory at your convenience.");
     }
 }

--- a/src/main/java/com/troblecodings/launcher/util/FileUtil.java
+++ b/src/main/java/com/troblecodings/launcher/util/FileUtil.java
@@ -147,37 +147,21 @@ public class FileUtil {
 
     // Delete option files and mod, assets and libraries folder
     public static void resetFiles() {
-        log.info("Started launcher reset!");
-        deleteFile(Paths.get(SETTINGS.baseDir + "/options.txt").toFile());
-        deleteFile(Paths.get(SETTINGS.baseDir + "/optionsof.txt").toFile());
-        deleteFile(Paths.get(SETTINGS.baseDir + "/GIR.json").toFile());
-        deleteDirectory(Paths.get(SETTINGS.baseDir + "/mods").toFile());
-        deleteDirectory(Paths.get(SETTINGS.baseDir + "/assets").toFile());
-        deleteDirectory(Paths.get(SETTINGS.baseDir + "/libraries").toFile());
-        deleteDirectory(Paths.get(SETTINGS.baseDir + "/config").toFile());
-        FileUtil.init();
-        log.info("Finished launcher reset!");
-    }
+        log.info("Reset requested.");
 
-    private static void deleteDirectory(File directory) {
-        if (directory != null && directory.exists()) {
-            File[] files = directory.listFiles();
-            if (null != files) {
-                for (int i = 0; i < files.length; i++) {
-                    if (files[i].isDirectory()) {
-                        deleteDirectory(files[i]);
-                    } else {
-                        files[i].delete();
-                    }
-                }
-            }
-            directory.delete();
-        }
-    }
+        try {
+            FileUtils.delete(Paths.get(SETTINGS.baseDir + "/options.txt").toFile());
+            FileUtils.delete(Paths.get(SETTINGS.baseDir + "/optionsof.txt").toFile());
+            FileUtils.delete(Paths.get(SETTINGS.baseDir + "/GIR.json").toFile());
+            FileUtils.deleteDirectory(Paths.get(SETTINGS.baseDir + "/mods").toFile());
+            FileUtils.deleteDirectory(Paths.get(SETTINGS.baseDir + "/assets").toFile());
+            FileUtils.deleteDirectory(Paths.get(SETTINGS.baseDir + "/libraries").toFile());
+            FileUtils.deleteDirectory(Paths.get(SETTINGS.baseDir + "/config").toFile());
+            FileUtil.init();
 
-    private static void deleteFile(File file) {
-        if (file != null && file.exists() && !file.isDirectory()) {
-            file.delete();
+            log.info("Reset complete.");
+        } catch (final IOException e) {
+            log.error("Reset operation failed: ", e);
         }
     }
 

--- a/src/main/java/com/troblecodings/launcher/util/FileUtil.java
+++ b/src/main/java/com/troblecodings/launcher/util/FileUtil.java
@@ -2,6 +2,7 @@ package com.troblecodings.launcher.util;
 
 import com.google.gson.Gson;
 import com.troblecodings.launcher.Launcher;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -14,6 +15,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.stream.Stream;
 
 public class FileUtil {
 
@@ -195,8 +198,9 @@ public class FileUtil {
             return;
         }
 
-        Files.delete(LauncherPaths.getDataDir());
-        Files.move(oldPath, LauncherPaths.getDataDir());
+        FileUtils.deleteDirectory(LauncherPaths.getDataDir().toFile());
+        FileUtils.moveDirectory(oldPath.toFile(), LauncherPaths.getDataDir().toFile());
+
         log.info("Migrated old directory to new location.");
     }
 }


### PR DESCRIPTION
Migrations have been suffering from Java requiring the directory to be empty when deleting it.
Additionally, I might have bumbled my way through the logic :trollface: 

Fixes:
- We are now first relativizing the relative path to the old location, and then resolving it against the new base path
- Directory deletion logic has been removed for now, and we are just copying files now instead of moving them. Deletion can be introduced possibly via command-line flag.

Locally tested to work, but verification by a second-party is welcome. Please run the Launcher from the CLI with the `-d` or ```--debug``` flag.

Closes #93.